### PR TITLE
updated classloader to use fully qualified name

### DIFF
--- a/src/main/java/com/hazelcast/hibernate4/instance/HazelcastInstanceFactory.java
+++ b/src/main/java/com/hazelcast/hibernate4/instance/HazelcastInstanceFactory.java
@@ -25,7 +25,7 @@ import java.util.Properties;
 public final class HazelcastInstanceFactory {
 
     private final static String HZ_CLIENT_LOADER_CLASSNAME = "com.hazelcast.HazelcastClientLoader";
-    private final static String HZ_INSTANCE_LOADER_CLASSNAME = "HazelcastInstanceLoader";
+    private final static String HZ_INSTANCE_LOADER_CLASSNAME = "com.hazelcast.hibernate4.instance.HazelcastInstanceLoader";
 
     public static HazelcastInstance createInstance(Properties props) throws CacheException {
         return createInstanceLoader(props).loadInstance();


### PR DESCRIPTION
The classloader in HazelcastInstanceFactory fail because HZ_INSTANCE_LOADER_CLASSNAME="HazelcastInstanceLoader" is not a fully qualfied name.
